### PR TITLE
Corrected path.join usage

### DIFF
--- a/server.js
+++ b/server.js
@@ -2,7 +2,6 @@ const express = require('express')
 const app = express()
 var path = require('path')
 
-
-app.get('/', (req, res) => res.sendFile(path.join(__dirname + '/public/index.html')));
+app.get('/', (req, res) => res.sendFile(path.join(__dirname, '/public/index.html')));
 
 app.listen(3000, () => console.log('rose has set up a server, bitches'))


### PR DESCRIPTION
path.join will join all arguments passed into it, so no need to concat them yourself.