### PR TITLE
Removed redundant variable assignment

### DIFF
--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,9 +1,6 @@
-import { combineReducers } from 'redux'
-import booking from './booking'
+import { combineReducers } from 'redux';
+import booking from './booking';
 
-
-const bookingApp = combineReducers({
+export default combineReducers({
   booking,
-})
-
-export default bookingApp
+});


### PR DESCRIPTION
Unless you plan to use the variable later, you can safely just export the result directly